### PR TITLE
client: add custom metadata

### DIFF
--- a/src/sajari.js
+++ b/src/sajari.js
@@ -85,6 +85,39 @@ export class Client {
     assertString("endpoint", endpoint);
     /** @private */
     this.e = endpoint;
+
+    /** @private */
+    this.customMetadata = {};
+  }
+
+  /**
+   * Sets custom metadata on the Client to be sent along with search requests
+   * @param {Object} metadata A map of metadata values
+   */
+  setCustomMetadata(metadata) {
+    Object.keys(metadata).forEach(key => {
+      if (!(metadata[key] instanceof Array)) {
+        throw new Error(
+          `metadata values must be arrays, value of "${key}" is invalid`
+        );
+      }
+    });
+    this.customMetadata = metadata;
+  }
+
+  /**
+   * Gets metadata values, includes both Client default metadata and custom metadata
+   * @returns {Object}
+   */
+  getMetadata() {
+    const metadata = {};
+    Object.keys(this.customMetadata).forEach(key => {
+      metadata[key] = this.customMetadata[key];
+    });
+    metadata["project"] = [this.p];
+    metadata["collection"] = [this.c];
+    metadata["user-agent"] = [userAgent];
+    return metadata;
   }
 
   /**
@@ -107,11 +140,7 @@ export class Client {
           data: tracking.data
         }
       },
-      metadata: {
-        project: [this.p],
-        collection: [this.c],
-        "user-agent": [userAgent]
-      }
+      metadata: this.getMetadata()
     });
 
     return makeRequest(
@@ -155,11 +184,7 @@ export class Client {
         },
         values: stringifiedValues
       },
-      metadata: {
-        project: [this.p],
-        collection: [this.c],
-        "user-agent": [userAgent]
-      }
+      metadata: this.getMetadata()
     });
 
     return makeRequest(

--- a/src/sajari.test.js
+++ b/src/sajari.test.js
@@ -1,6 +1,14 @@
-import { userAgent } from "./sajari";
+import { userAgent, Client } from "./sajari";
 
 test("package version in code matches package", () => {
   const packageVersion = require("../package.json").version;
   expect(userAgent).toBe("sdk-js-" + packageVersion);
+});
+
+test("setting and getting custom metadata", () => {
+  const client = new Client("", "");
+  const key = "foo";
+  const value = ["bar"];
+  client.setCustomMetadata({ [key]: value });
+  expect(client.getMetadata()).toHaveProperty(key, value);
 });


### PR DESCRIPTION
Currently it's not possible for users of the sdk to set custom metadata. This PR adds methods for setting custom metadata and getting the current metadata of the client.