### PR TITLE
pipeline: fix missing pipelines in listPipelines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - "8"
 
-install: yarn install
+install: npm install
 script:
   - npm test
   - npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -11232,9 +11232,9 @@
       }
     },
     "typescript": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
+      "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==",
       "dev": true
     },
     "uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@sajari/sdk-js",
-  "version": "2.0.0-alpha.9",
+  "version": "2.0.0-alpha.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "search",
     "search api"
   ],
-  "version": "2.0.0-alpha.9",
+  "version": "2.0.0-alpha.10",
   "main": "dist/index.js",
   "umd:main": "dist/sajarisdk.umd.production.js",
   "module": "dist/sajarisdk.esm.production.js",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "tsdx": "^0.13.2",
     "tslib": "^1.11.1",
     "typedoc": "^0.17.4",
-    "typescript": "^3.8.3"
+    "typescript": "^3.9.6"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,7 +155,7 @@ export class Client {
       );
 
       pipelines = pipelines.concat(
-        resp.pipelines.map((pipeline) => {
+        resp.pipelines?.map((pipeline) => {
           const preStepsProto = pipeline.steps.find(
             (step) => step.stepType === "PRE_STEP"
           ) || { steps: undefined };
@@ -200,7 +200,7 @@ export class Client {
               postSteps,
             },
           };
-        })
+        }) ?? []
       );
       if (
         resp.nextPageToken === "" ||
@@ -339,7 +339,7 @@ function constConfigToParam(
  * @hidden
  */
 interface ListPipelinesProto {
-  pipelines: PipelineProto[];
+  pipelines?: PipelineProto[];
   nextPageToken?: string;
 }
 

--- a/src/user-agent.ts
+++ b/src/user-agent.ts
@@ -4,4 +4,4 @@
  * user agent of sdk
  * @hidden
  */
-export const USER_AGENT = "sdk-js-2.0.0-alpha.9";
+export const USER_AGENT = "sdk-js-2.0.0-alpha.10";


### PR DESCRIPTION
/sajari.pipeline.v2.PipelineAdmin/ListPipelines can return an empty
object `{}` with no `pipelines` field.