### PR TITLE
fix: undefined posneg token

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -376,6 +376,11 @@ class QueryPipeline extends EventEmitter {
             t = { click: clickTokenURL + token.click.token };
           } else if ("pos" in token) {
             t = { ...token };
+          } else if ("posNeg" in token) {
+            t = {
+              pos: token.posNeg.pos,
+              neg: token.posNeg.neg,
+            };
           }
         }
 
@@ -506,6 +511,12 @@ type TokenProto =
   | {
       pos: string;
       neg: string;
+    }
+  | {
+      posNeg: {
+        pos: string;
+        neg: string;
+      };
     };
 
 /**


### PR DESCRIPTION
In the `master` branch the token is populated correctly but when moved to `v2` a check is missing
https://github.com/sajari/sajari-sdk-js/blob/0d5740a723c437584c0a87215e3c90e52ca4b7f5/src/constructors.ts#L112
## What does this PR do?
- [x] Add the missing check needed to populate the `token` field correctly